### PR TITLE
🐎 ci: add E2E tests workflow

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,0 +1,35 @@
+name: Run E2E Tests
+
+on: [pull_request]
+
+jobs:
+  run-e2e-tests:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+
+  services:
+    postgres:
+    image: 'bitnami/postgresql'
+    environment:
+      - POSTGRESQL_USERNAME=docker
+      - POSTGRESQL_PASSWORD=docker
+      - POSTGRESQL_DATABASE=apisolid
+    ports:
+      - '5432:5432'
+
+  steps:
+      - uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.15.3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.16.0
+          cache: 'pnpm'
+
+      - run: pnpm install
+      - run: pnpm test:e2e
+        env: 
+          JWT_SECRET: testing
+          DATABASE_URL: "postgresql://docker:docker@localhost:5432/apisolid?schema=public"


### PR DESCRIPTION
## Adding a E2E tests workflow

- [x] Configured a postgres docker image 
- [x] Configured node ambient
- [x] Configured env vars